### PR TITLE
Add primitive index.html as default redirect

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,8 +1,14 @@
+<!DOCTYPE HTML>
 <html>
 <head>
-<meta http-equiv="Refresh" content="0; url='https://forestclaw.github.io/docs/develop/'"/>
+<title>ForestClaw Documentation</title>
+<meta http-equiv="refresh" content="0; url='https://forestclaw.github.io/docs/develop/'">
 </head>
 <body>
-<p><a href="https://forestclaw.github.io/docs/develop/">Link to documentation</a></p>
+<p>
+If you are not redirected automatically, please follow this
+<a href="https://forestclaw.github.io/docs/develop/">link</a>
+to the ForestClaw documentation.
+</p>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+<meta http-equiv="Refresh" content="0; url='https://forestclaw.github.io/docs/develop/'"/>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,5 +1,8 @@
 <html>
-<body>
+<head>
 <meta http-equiv="Refresh" content="0; url='https://forestclaw.github.io/docs/develop/'"/>
+</head>
+<body>
+<p><a href="https://forestclaw.github.io/docs/develop/">Link to documentation</a></p>
 </body>
 </html>


### PR DESCRIPTION
We didn't have a toplevel `index.html` file, just added a redirect to docs/develop as a start.